### PR TITLE
update gradle-build-action to 2.4.2

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -25,19 +25,19 @@ jobs:
           check-latest: true
 
       - name: checkFormat
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: checkFormat
 
       - name: assemble
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: assemble
 
       - name: test
         env:
           API_TOKEN: ${{ secrets.API_TOKEN }}
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: test
 


### PR DESCRIPTION
Fixing a security vulnerability by updating to gradle-build-action v2.4.2