### PR TITLE
fix not showing shared arrays

### DIFF
--- a/src/main/java/io/tiledb/TileDBCloudConnection.java
+++ b/src/main/java/io/tiledb/TileDBCloudConnection.java
@@ -140,12 +140,15 @@ public class TileDBCloudConnection implements java.sql.Connection {
     }
 
     try {
+
+      List<String> sharedTo = Arrays.asList(namespace);
+
       ArrayBrowserData resultShared =
           arrayApi.arraysBrowserSharedGet(
               null,
               null,
               null,
-              namespace,
+              null,
               null,
               null,
               null,
@@ -153,7 +156,7 @@ public class TileDBCloudConnection implements java.sql.Connection {
               null,
               excludeFileType,
               null,
-              null);
+              sharedTo);
       tileDBCloudDatabaseMetadata.setArraysShared(resultShared);
     } catch (Exception e) {
     }

--- a/src/main/java/io/tiledb/TileDBCloudTablesResultSet.java
+++ b/src/main/java/io/tiledb/TileDBCloudTablesResultSet.java
@@ -72,7 +72,7 @@ public class TileDBCloudTablesResultSet implements ResultSet {
 
   @Override
   public String getString(int columnIndex) throws SQLException {
-    return "tiledb://" + namespace + "/" + currentArray.getName();
+    return currentArray.getTiledbUri();
   }
 
   @Override
@@ -169,7 +169,7 @@ public class TileDBCloudTablesResultSet implements ResultSet {
 
     switch (columnLabel) {
       case "TABLE_NAME":
-        return "tiledb://" + this.namespace + "/" + this.currentArray.getName();
+        return currentArray.getTiledbUri();
       case "REMARKS":
         return ownership;
       case "TABLE_TYPE":

--- a/src/main/java/io/tiledb/util/Util.java
+++ b/src/main/java/io/tiledb/util/Util.java
@@ -2,12 +2,12 @@ package io.tiledb.util;
 
 public class Util {
   public static int VERSION_MINOR = 1;
-  public static final int VERSION_REVISION = 0;
+  public static final int VERSION_REVISION = 3;
   public static int VERSION_MAJOR = 0;
 
-  public static int TILEDB_CLOUD_VERSION_MINOR = 9;
-  public static int TILEDB_CLOUD_VERSION_REVISION = 0;
+  public static int TILEDB_CLOUD_VERSION_MINOR = 0;
+  public static int TILEDB_CLOUD_VERSION_REVISION = 2;
   public static int TILEDB_CLOUD_VERSION_MAJOR = 0;
 
-  public static String SCHEMA_NAME = "TileDB Schema";
+  public static String SCHEMA_NAME = "All TileDB arrays";
 }


### PR DESCRIPTION
This PR now lists all arrays owned by or shared to the user. This was the intented behavior but there was an issue. 