### PR TITLE
improve array listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Other available properties are:
 - ```password(String)```
 - ```verifySSL(boolean)```
 - ```overwritePrevious(boolean)```
+- ```listPublicArrays(boolean)``` lists all public TileDB arrays. Default: ```true```
 
 ## Run a simple query
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'project-report'
 
 
 group 'io.tiledb'
-version '0.3.1-SNAPSHOT'
+version '0.3.2-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -8,7 +8,7 @@ public class Examples {
     //        Properties properties  = new Properties();
     //        properties.setProperty("apiKey", "KEY");
     //        properties.setProperty("rememberMe", "true");
-    try (Connection conn = DriverManager.getConnection("jdbc:tiledb-cloud:<NAMESPACE>");
+    try (Connection conn = DriverManager.getConnection("jdbc:tiledb-cloud:TileDB-Inc");
         Statement stmt = conn.createStatement();
         ResultSet rs =
             stmt.executeQuery("SELECT * FROM `tiledb://TileDB-Inc/quickstart_sparse`"); ) {

--- a/src/main/java/io/tiledb/TileDBCloudDatabaseMetadata.java
+++ b/src/main/java/io/tiledb/TileDBCloudDatabaseMetadata.java
@@ -11,6 +11,8 @@ public class TileDBCloudDatabaseMetadata implements DatabaseMetaData {
 
   private ArrayBrowserData arraysOwned;
   private ArrayBrowserData arraysShared;
+  private ArrayBrowserData arraysPublic;
+
   private String namespace;
 
   private Logger logger = Logger.getLogger(TileDBCloudDatabaseMetadata.class.getName());
@@ -628,7 +630,7 @@ public class TileDBCloudDatabaseMetadata implements DatabaseMetaData {
       String catalog, String schemaPattern, String tableNamePattern, String[] types)
       throws SQLException {
     logger.log(Level.INFO, "Requesting arrays from TileDB");
-    return new TileDBCloudTablesResultSet(this.arraysOwned, this.arraysShared, this.namespace);
+    return new TileDBCloudTablesResultSet(this.arraysOwned, this.arraysShared, this.arraysPublic);
   }
 
   @Override
@@ -655,7 +657,7 @@ public class TileDBCloudDatabaseMetadata implements DatabaseMetaData {
       String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
       throws SQLException {
     logger.log(Level.INFO, "Requesting columns for array: " + tableNamePattern);
-    return new TileDBCloudColumnsResultSet(tableNamePattern, namespace, arrayApi);
+    return new TileDBCloudColumnsResultSet(tableNamePattern, arrayApi);
   }
 
   @Override
@@ -957,6 +959,10 @@ public class TileDBCloudDatabaseMetadata implements DatabaseMetaData {
 
   public void setArraysShared(ArrayBrowserData result) {
     this.arraysShared = result;
+  }
+
+  public void setArraysPublic(ArrayBrowserData resultPublic) {
+    this.arraysPublic = resultPublic;
   }
 
   public void setNamespace(String namespace) {

--- a/src/main/java/io/tiledb/TileDBCloudDriver.java
+++ b/src/main/java/io/tiledb/TileDBCloudDriver.java
@@ -26,8 +26,11 @@ public class TileDBCloudDriver implements Driver {
     if (parts.length == 4) token = parts[3]; // the fourth part should be the token
 
     // call the appropriate connector depending on the properties given
-    if (properties.isEmpty() && token.equals("")) return new TileDBCloudConnection(namespace);
-    return new TileDBCloudConnection(namespace, createLoginObject(properties));
+    boolean listPublicArrays =
+        Boolean.parseBoolean((String) properties.getOrDefault("listPublicArrays", "true"));
+    if (properties.isEmpty() && token.equals(""))
+      return new TileDBCloudConnection(namespace, listPublicArrays);
+    return new TileDBCloudConnection(namespace, createLoginObject(properties), listPublicArrays);
   }
 
   /**

--- a/src/main/java/io/tiledb/TileDBCloudStatement.java
+++ b/src/main/java/io/tiledb/TileDBCloudStatement.java
@@ -6,6 +6,7 @@ import io.tiledb.cloud.rest_api.api.SqlApi;
 import io.tiledb.cloud.rest_api.model.ResultFormat;
 import io.tiledb.cloud.rest_api.model.SQLParameters;
 import io.tiledb.java.api.Pair;
+import io.tiledb.util.Util;
 import java.sql.*;
 import java.util.ArrayList;
 import org.apache.arrow.vector.ValueVector;
@@ -38,7 +39,7 @@ public class TileDBCloudStatement implements Statement {
   public ResultSet executeQuery(String s) throws SQLException {
     // create SQL parameters
     SQLParameters sqlParameters = new SQLParameters();
-    sqlParameters.setQuery(s);
+    sqlParameters.setQuery(Util.replaceArrayNamesWithUUIDs(s));
     // get results in arrow format
     sqlParameters.setResultFormat(ResultFormat.ARROW);
 

--- a/src/main/java/io/tiledb/util/Util.java
+++ b/src/main/java/io/tiledb/util/Util.java
@@ -1,5 +1,8 @@
 package io.tiledb.util;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class Util {
   public static int VERSION_MINOR = 1;
   public static final int VERSION_REVISION = 3;
@@ -10,4 +13,43 @@ public class Util {
   public static int TILEDB_CLOUD_VERSION_MAJOR = 0;
 
   public static String SCHEMA_NAME = "All TileDB arrays";
+
+  /**
+   * Replaces all array names with the corresponding UUID if the input string is of a specific
+   * pattern
+   *
+   * @param completeURI If the input string is of the form "tiledb://TileDB-Inc/orders ~
+   *     tiledb://TileDB-Inc/120f0518-dd8d-467f-8c1b-23aa49929465" this method will modify the input
+   *     string to only use the TileDB URI with the UUID. If an input string does not match the
+   *     regex pattern specified in the Pattern.compile method, the Matcher will not find any
+   *     matches, and the code will simply return the original input string as it is without making
+   *     any modifications.
+   * @return
+   */
+  public static String replaceArrayNamesWithUUIDs(String completeURI) {
+    // Define the regular expression pattern for the TileDB URI pattern with spaces around "~"
+    String regex = "(tiledb://[^~]+) ~ ([^\\s]+)";
+    Pattern pattern = Pattern.compile(regex);
+
+    Matcher matcher = pattern.matcher(completeURI);
+    StringBuilder modifiedText = new StringBuilder();
+
+    // Find and remove the first part in TileDB URIs
+    int lastEnd = 0;
+    while (matcher.find()) {
+      // Append the text before the match and a space
+      modifiedText.append(completeURI.substring(lastEnd, matcher.start(1)));
+
+      // Append the text after "~" and a space
+      modifiedText.append(matcher.group(2));
+
+      // Update the lastEnd to the end of this match
+      lastEnd = matcher.end();
+    }
+
+    // Append any remaining text after the last match
+    modifiedText.append(completeURI.substring(lastEnd));
+
+    return modifiedText.toString().trim();
+  }
 }


### PR DESCRIPTION
This PR will improve the way the JDBC driver lists arrays. 

- First it makes all names readable and changes the current behavior which was to display the tiledbURI. 
- Second, it now displays all public arrays as well. Unless otherwise instructed (introduced new option)
- Lastly, fixes a bug in which the wrong namespace was used to query arrays when asking for a preview.