### PR TITLE
fix array listing in Tableau

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'project-report'
 
 
 group 'io.tiledb'
-version '0.3.2-SNAPSHOT'
+version '0.3.3-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/tiledb/TileDBCloudColumnsResultSet.java
+++ b/src/main/java/io/tiledb/TileDBCloudColumnsResultSet.java
@@ -1,6 +1,5 @@
 package io.tiledb;
 
-import static io.tiledb.util.Util.replaceArrayNamesWithUUIDs;
 import static java.sql.DatabaseMetaData.columnNoNulls;
 import static java.sql.DatabaseMetaData.columnNullable;
 
@@ -36,8 +35,7 @@ public class TileDBCloudColumnsResultSet implements ResultSet {
     this.completeURI = completeURI;
     this.nullable = columnNoNulls;
 
-    String URIWithUUID = replaceArrayNamesWithUUIDs(completeURI);
-    String[] split = URIWithUUID.split("/");
+    String[] split = completeURI.split("/");
     String arrayUUIDClean = split[split.length - 1];
     String arrayNamespaceClean = split[split.length - 2];
 

--- a/src/main/java/io/tiledb/TileDBCloudDatabaseMetadata.java
+++ b/src/main/java/io/tiledb/TileDBCloudDatabaseMetadata.java
@@ -70,11 +70,7 @@ public class TileDBCloudDatabaseMetadata implements DatabaseMetaData {
 
   @Override
   public String getDatabaseProductVersion() throws SQLException {
-    return Util.TILEDB_CLOUD_VERSION_MAJOR
-        + "."
-        + Util.TILEDB_CLOUD_VERSION_REVISION
-        + "."
-        + Util.TILEDB_CLOUD_VERSION_MINOR;
+    return Util.VERSION_MAJOR + "." + Util.VERSION_REVISION + "." + Util.VERSION_MINOR;
   }
 
   @Override

--- a/src/main/java/io/tiledb/TileDBCloudResultSet.java
+++ b/src/main/java/io/tiledb/TileDBCloudResultSet.java
@@ -48,6 +48,7 @@ public class TileDBCloudResultSet implements ResultSet {
 
   @Override
   public boolean next() throws SQLException {
+    if (valueVectors == null) return false;
     if (valueVectors.get(currentBatch).getValueCount() - 1 > currentRow) {
       currentRow++;
       globalRowCount++;
@@ -109,7 +110,12 @@ public class TileDBCloudResultSet implements ResultSet {
 
   @Override
   public double getDouble(int i) throws SQLException {
-    return (double) valueVectors.get(i - 1 + (currentBatch * fieldsPerBatch)).getObject(currentRow);
+    try {
+      return (double)
+          valueVectors.get(i - 1 + (currentBatch * fieldsPerBatch)).getObject(currentRow);
+    } catch (java.lang.ClassCastException e) {
+      return getFloat(i);
+    }
   }
 
   @Override
@@ -398,7 +404,7 @@ public class TileDBCloudResultSet implements ResultSet {
 
   @Override
   public int getType() throws SQLException {
-    return 0;
+    return ResultSet.TYPE_FORWARD_ONLY;
   }
 
   @Override

--- a/src/main/java/io/tiledb/TileDBCloudStatement.java
+++ b/src/main/java/io/tiledb/TileDBCloudStatement.java
@@ -6,7 +6,6 @@ import io.tiledb.cloud.rest_api.api.SqlApi;
 import io.tiledb.cloud.rest_api.model.ResultFormat;
 import io.tiledb.cloud.rest_api.model.SQLParameters;
 import io.tiledb.java.api.Pair;
-import io.tiledb.util.Util;
 import java.sql.*;
 import java.util.ArrayList;
 import org.apache.arrow.vector.ValueVector;
@@ -39,7 +38,7 @@ public class TileDBCloudStatement implements Statement {
   public ResultSet executeQuery(String s) throws SQLException {
     // create SQL parameters
     SQLParameters sqlParameters = new SQLParameters();
-    sqlParameters.setQuery(Util.replaceArrayNamesWithUUIDs(s));
+    sqlParameters.setQuery(s);
     // get results in arrow format
     sqlParameters.setResultFormat(ResultFormat.ARROW);
 

--- a/src/main/java/io/tiledb/TileDBCloudTablesResultSetMetadata.java
+++ b/src/main/java/io/tiledb/TileDBCloudTablesResultSetMetadata.java
@@ -11,16 +11,26 @@ import java.util.logging.Logger;
 public class TileDBCloudTablesResultSetMetadata implements ResultSetMetaData {
   private Logger logger = Logger.getLogger(TileDBCloudTablesResultSetMetadata.class.getName());
 
-  private List<ArrayInfo> arrays;
+  private List<ArrayInfo> arraysOwned;
+  private List<ArrayInfo> arraysShared;
+  private List<ArrayInfo> arraysPublic;
+  private int numberOfArrays;
 
-  public TileDBCloudTablesResultSetMetadata(List<ArrayInfo> arrays) {
-    this.arrays = arrays;
+  public TileDBCloudTablesResultSetMetadata(
+      List<ArrayInfo> arraysOwned,
+      List<ArrayInfo> arraysShared,
+      List<ArrayInfo> arraysPublic,
+      int numberOfArrays) {
+    this.arraysOwned = arraysOwned;
+    this.arraysShared = arraysShared;
+    this.arraysPublic = arraysPublic;
+    this.numberOfArrays = numberOfArrays;
   }
 
   @Override
   public int getColumnCount() throws SQLException {
-    if (arrays == null) return 0;
-    return arrays.size();
+    if (this.numberOfArrays == 0) return 0;
+    return 5; // refers to the number of column Labels from TileDBCloudTablesResultSet which are 5
   }
 
   @Override
@@ -65,7 +75,19 @@ public class TileDBCloudTablesResultSetMetadata implements ResultSetMetaData {
 
   @Override
   public String getColumnName(int column) throws SQLException {
-    return arrays.get(column - 1).getName();
+    if (column < arraysOwned.size()) {
+      return arraysOwned.get(column - 1).getName();
+    }
+
+    if (column - arraysOwned.size() < arraysShared.size()) {
+      return arraysShared.get(column - arraysOwned.size() - 1).getName();
+    }
+
+    if (column - arraysOwned.size() - arraysShared.size() < arraysPublic.size()) {
+      return arraysPublic.get(column - arraysOwned.size() - arraysShared.size() - 1).getName();
+    }
+
+    return "";
   }
 
   @Override

--- a/src/main/java/io/tiledb/util/Util.java
+++ b/src/main/java/io/tiledb/util/Util.java
@@ -6,7 +6,7 @@ import java.util.regex.Pattern;
 public class Util {
   public static int VERSION_MINOR = 1;
   public static final int VERSION_REVISION = 3;
-  public static int VERSION_MAJOR = 0;
+  public static int VERSION_MAJOR = 3;
 
   public static int TILEDB_CLOUD_VERSION_MINOR = 0;
   public static int TILEDB_CLOUD_VERSION_REVISION = 2;


### PR DESCRIPTION
This PR fixes the array listing in Tableau. 

It also reverts to only using the array names in the listing ignoring the fact that there might be arrays with duplicate names. 
The previous version was displaying each array with a name of the form: 
```tiledb://namespace/name ~ tiledb://namespace/uuid```. 

This however was causing problems in Tableau because:
1. it was modifying the name and
2.  it was shortening the name. 

and this made it difficult for us to collect the info we wanted which is the tiledbURI.


An example of the logs can be seen here:

```
2023-09-15 13:08:18.304 +0300 (,,,,9,93) grpc-default-executor-3 : INFO  com.tableau.connect.service.ProtocolService - Running query 
   SELECT `tiledb___shaunreed_dense-array-char-dimensions ~ tiledb___shau`.`a1` AS `a1`,
     `tiledb___shaunreed_dense-array-char-dimensions ~ tiledb___shau`.`cols` AS `cols`,
     `tiledb___shaunreed_dense-array-char-dimensions ~ tiledb___shau`.`rows` AS `rows`
   FROM `tiledb://shaunreed/dense-array-char-dimensions ~ tiledb://shaunreed/e8a09831-53a2-4477-9f3e-bd2b82a809ec`.`tiledb://shaunreed/dense-array-char-dimensions ~ tiledb://shaunreed/e8a09831-53a2-4477-9f3e-bd2b82a809ec` `tiledb___shaunreed_dense-array-char-dimensions ~ tiledb___shau`
   LIMIT 100
```

As you can see Tableau modifies the name in various ways and I deemed appropriate to step away from trying to make this work as I think we will just introduce more errors and edge cases. 

Now, if a user tries to view the data from an array with a duplicate name he/she will receive an error message. He/She can then proceed to query the specific array from the "Custom SQL" field in both Tableau and Power BI by using the UUID. We could instead list all the arrays with their tiledbURI but this would look ugly.

This PR has been tested in Both Tableau and Power BI

Screenshots below:


<img width="719" alt="Screenshot 2023-09-15 at 5 29 47 PM" src="https://github.com/TileDB-Inc/TileDB-Cloud-JDBC/assets/33267511/68757721-2ba3-4828-8dfb-e2f0429d38dc">
<img width="2547" alt="Screenshot 2023-09-15 at 5 32 23 PM" src="https://github.com/TileDB-Inc/TileDB-Cloud-JDBC/assets/33267511/cb4a66b6-5c64-42eb-867b-3169ee8c3377">
<img width="2450" alt="Screenshot 2023-09-15 at 5 32 55 PM" src="https://github.com/TileDB-Inc/TileDB-Cloud-JDBC/assets/33267511/1903a582-d250-484d-afff-1866867945e6">
