### PR TITLE
deal with arrays with the same name in BI tools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
+    implementation 'com.google.guava:guava:32.1.2-jre'
     implementation group: 'io.tiledb', name: 'tiledb-cloud-java', version: '0.2.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'project-report'
 
 
 group 'io.tiledb'
-version '0.3.3-SNAPSHOT'
+version '0.3.4-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/tiledb/TileDBCloudColumnsResultSet.java
+++ b/src/main/java/io/tiledb/TileDBCloudColumnsResultSet.java
@@ -6,6 +6,7 @@ import static java.sql.DatabaseMetaData.columnNullable;
 import io.tiledb.cloud.rest_api.ApiException;
 import io.tiledb.cloud.rest_api.api.ArrayApi;
 import io.tiledb.cloud.rest_api.model.*;
+import io.tiledb.util.Util;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -31,11 +32,11 @@ public class TileDBCloudColumnsResultSet implements ResultSet {
 
   public TileDBCloudColumnsResultSet(String completeURI, ArrayApi arrayApi) {
     this.columnCounter = -1;
-    // the complete URI contains both the name and the UUID
+    // the complete URI contains both the name and the short-UUID
     this.completeURI = completeURI;
     this.nullable = columnNoNulls;
-
-    String[] split = completeURI.split("/");
+    String withoutUUID = Util.removeUUID(completeURI);
+    String[] split = withoutUUID.split("/");
     String arrayUUIDClean = split[split.length - 1];
     String arrayNamespaceClean = split[split.length - 2];
 

--- a/src/main/java/io/tiledb/TileDBCloudStatement.java
+++ b/src/main/java/io/tiledb/TileDBCloudStatement.java
@@ -6,6 +6,7 @@ import io.tiledb.cloud.rest_api.api.SqlApi;
 import io.tiledb.cloud.rest_api.model.ResultFormat;
 import io.tiledb.cloud.rest_api.model.SQLParameters;
 import io.tiledb.java.api.Pair;
+import io.tiledb.util.Util;
 import java.sql.*;
 import java.util.ArrayList;
 import org.apache.arrow.vector.ValueVector;
@@ -38,7 +39,8 @@ public class TileDBCloudStatement implements Statement {
   public ResultSet executeQuery(String s) throws SQLException {
     // create SQL parameters
     SQLParameters sqlParameters = new SQLParameters();
-    sqlParameters.setQuery(s);
+    String query = Util.useTileDBUris(s);
+    sqlParameters.setQuery(query);
     // get results in arrow format
     sqlParameters.setResultFormat(ResultFormat.ARROW);
 

--- a/src/main/java/io/tiledb/TileDBCloudTablesResultSet.java
+++ b/src/main/java/io/tiledb/TileDBCloudTablesResultSet.java
@@ -13,6 +13,7 @@ import java.util.*;
 import java.util.logging.Logger;
 
 public class TileDBCloudTablesResultSet implements ResultSet {
+  public static HashMap<String, String> uris = new HashMap<>();
   private List<ArrayInfo> arraysOwned = new ArrayList<ArrayInfo>();
   private List<ArrayInfo> arraysShared = new ArrayList<ArrayInfo>();
   private List<ArrayInfo> arraysPublic = new ArrayList<ArrayInfo>();
@@ -37,6 +38,31 @@ public class TileDBCloudTablesResultSet implements ResultSet {
 
     this.numberOfArrays =
         this.arraysOwned.size() + this.arraysShared.size() + this.arraysPublic.size();
+    populateURIs();
+  }
+
+  private void populateURIs() {
+
+    // Iterate through arraysOwned and add entries to the HashMap
+    for (ArrayInfo arrayInfo : arraysOwned) {
+      String key = Util.getUUIDStart(arrayInfo.getTiledbUri());
+      String value = arrayInfo.getTiledbUri();
+      uris.put(key, value);
+    }
+
+    // Iterate through arraysShared and add entries to the HashMap
+    for (ArrayInfo arrayInfo : arraysShared) {
+      String key = Util.getUUIDStart(arrayInfo.getTiledbUri());
+      String value = arrayInfo.getTiledbUri();
+      uris.put(key, value);
+    }
+
+    // Iterate through arraysPublic and add entries to the HashMap
+    for (ArrayInfo arrayInfo : arraysPublic) {
+      String key = Util.getUUIDStart(arrayInfo.getTiledbUri());
+      String value = arrayInfo.getTiledbUri();
+      uris.put(key, value);
+    }
   }
 
   public TileDBCloudTablesResultSet() {
@@ -78,7 +104,13 @@ public class TileDBCloudTablesResultSet implements ResultSet {
 
   @Override
   public String getString(int columnIndex) throws SQLException {
-    return "tiledb://" + currentArray.getNamespace() + "/" + currentArray.getName();
+    return "[tiledb://"
+        + currentArray.getNamespace()
+        + "/"
+        + currentArray.getName()
+        + "]["
+        + Util.getUUIDStart(currentArray.getTiledbUri())
+        + "]";
   }
 
   @Override
@@ -176,7 +208,13 @@ public class TileDBCloudTablesResultSet implements ResultSet {
 
     switch (columnLabel) {
       case "TABLE_NAME":
-        return "tiledb://" + currentArray.getNamespace() + "/" + currentArray.getName();
+        return "[tiledb://"
+            + currentArray.getNamespace()
+            + "/"
+            + currentArray.getName()
+            + "]["
+            + Util.getUUIDStart(currentArray.getTiledbUri())
+            + "]";
       case "REMARKS":
         return ownership + " TileDB URI: " + currentArray.getTiledbUri();
       case "TABLE_TYPE":

--- a/src/main/java/io/tiledb/util/Util.java
+++ b/src/main/java/io/tiledb/util/Util.java
@@ -44,7 +44,8 @@ public class Util {
       String key = matcher.group(3);
 
       String replacement =
-          TileDBCloudTablesResultSet.uris.getOrDefault(key, ""); // Get replacement from the map
+          TileDBCloudTablesResultSet.shortUUIDToUri.getOrDefault(
+              key, ""); // Get replacement from the map
       if (!replacement.equals(""))
         matcher.appendReplacement(
             result, replacement); // Replace the match with the corresponding value


### PR DESCRIPTION
This PR will solve the duplicate names issue. Every array listed also contains a small part of its UUID. (Tableau crops large array names that's why I am not putting the entire UUID like in a previous implementation). This part of the UUID is then used to fetch the entire tileDBURI from a static hash map.

Screenshot of both Tableau and Power BI below.  


<img width="2464" alt="Screenshot 2023-10-04 at 6 22 45 PM" src="https://github.com/TileDB-Inc/TileDB-Cloud-JDBC/assets/33267511/66d2a734-c399-46be-b641-96ed06afc205">


<img width="2516" alt="Screenshot 2023-10-04 at 6 26 45 PM" src="https://github.com/TileDB-Inc/TileDB-Cloud-JDBC/assets/33267511/58cd6a78-07ea-41a6-85aa-03c17164d82a">
