### PR TITLE
Migrate to macos-12

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-11 ]
+        os: [ ubuntu-latest, macos-12 ]
 
     steps:
       - name: checkout


### PR DESCRIPTION
macos-11 will be removed this Friday, 2024-06-28

https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal