### PR TITLE
Update GHA runners to macos-12

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-11 ]
+        os: [ ubuntu-latest, macos-12 ]
 
     steps:
       - name: checkout


### PR DESCRIPTION
This PR was originally opened by @jdblischak (#13). The CI in his PR fails because PRs from external contributors do not have access to the repo's secrets. In this case there is a repo secret in the form of an API token that gives access to TileDB-Cloud arrays. 

