### PR TITLE
Update actions to Node 20

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -15,29 +15,29 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '11'
           check-latest: false
 
       - name: checkFormat
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: checkFormat
 
       - name: assemble
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: assemble
 
       - name: test
         env:
           API_TOKEN: ${{ secrets.API_TOKEN }}
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: test
 
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '11'
@@ -82,10 +82,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '11'
@@ -96,7 +96,7 @@ jobs:
 
       - name: Create-Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
You can see the deprecation warnings in this [recent run](https://github.com/TileDB-Inc/TileDB-Cloud-JDBC/actions/runs/10421818648).

My last PR (#13) failed because I can't push to an internal branch (#14), so I suspect this one will fail too. Could either 1) I be added as a contributor to this repo so that I can create an internal branch, or 2) could a maintainer please push my change as an internal branch to test the CI?