### PR TITLE
Combine Windows CI with Ubuntu and macOS

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -9,43 +9,12 @@ on:
       - 'main'
   pull_request:
 
-
 jobs:
-  Test_Windows:
-    runs-on: windows-2019
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'adopt'
-          java-version: '11'
-          check-latest: false
-
-      - name: checkFormat
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: checkFormat
-
-      - name: assemble
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: assemble
-
-      - name: test
-        env:
-          API_TOKEN: ${{ secrets.API_TOKEN }}
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: test
-
-  Test_Ubuntu_macOS:
+  Test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12 ]
+        os: [ ubuntu-22.04, macos-12, windows-2019 ]
 
     steps:
       - name: checkout
@@ -77,7 +46,7 @@ jobs:
 
   Release:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [Test_Ubuntu_macOS, Test_Windows]
+    needs: [Test]
     name: Create-Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
My original plan was to upgrade gradle/gradle-build-action@v3 to gradle/actions/setup-gradle@v4 (https://github.com/TileDB-Inc/TileDB-Cloud-JDBC/pull/20#issuecomment-2302625132). However, after I had done that, the Windows CI looked so similar to the Ubuntu and macOS CI, that it felt unnecessary to keep separate.

In addition to combining the CI into a single job, I also replaced `ubuntu-latest` with `ubuntu-22.04`, as recently suggested in https://github.com/TileDB-Inc/TileDB-Cloud-JDBC/pull/14#discussion_r1661203769.

The only remaining difference for the separate Windows job was the use of the argument `check-latest: false` for [`actions/setup-java`](https://github.com/actions/setup-java/tree/v4/?tab=readme-ov-file#usage). There was no explanation in #6 to explain the discrepancy. I can switch it to `false` if desired.

