### PR TITLE
Migrate to macos-13 runner image

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-12, windows-2019 ]
+        os: [ ubuntu-22.04, macos-13, windows-2019 ]
 
     steps:
       - name: checkout


### PR DESCRIPTION
macos-12 runner image is deprecated

xref: https://github.com/actions/runner-images/issues/10721, https://github.com/TileDB-Inc/TileDB/pull/5350
