### PR TITLE
Migrate CI to windows-2022

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-13, windows-2019 ]
+        os: [ ubuntu-22.04, macos-13, windows-2022 ]
 
     steps:
       - name: checkout


### PR DESCRIPTION
The Windows Server 2019 image is deprecated in GitHub Actions ([announcement](https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/#windows-server-2019-is-closing-down)):

> This image will be fully retired by June 30, 2025.

xref: https://github.com/TileDB-Inc/TileDB-Java/pull/376