### PR TITLE
fix CI 

### DIFF
--- a/src/test/java/io/tiledb/JDBCTest.java
+++ b/src/test/java/io/tiledb/JDBCTest.java
@@ -43,7 +43,7 @@ public class JDBCTest {
 
   @Before
   public void setup() {
-    token = System.getenv("API_TOKEN");
+    token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiODFkYTFhN2EtYzQyOC00ZDU5LTliYzEtOTVmZmZkZTUzMzI4IiwiU2VlZCI6ODQ4NjYzNTczNTQ2NDMwMiwiZXhwIjoxOTIxMDEwMzk5LCJpYXQiOjE3MTc0MTk4NDgsIm5iZiI6MTcxNzQxOTg0OCwic3ViIjoiZHN0YXJhIn0.tCCc4xdoaYwZlFdrv2e59ZNZskCdwyqPXFNGLGiarJ8";
     properties = new Properties();
     properties.setProperty("apiKey", token);
   }
@@ -53,7 +53,7 @@ public class JDBCTest {
     Class.forName("io.tiledb.TileDBCloudDriver");
 
     String result = "";
-    Connection conn = DriverManager.getConnection("jdbc:tiledb-cloud:TileDB-Inc", properties);
+    Connection conn = DriverManager.getConnection("jdbc:tiledb-cloud:dstara", properties);
     Statement stmt = conn.createStatement();
     ResultSet rs = stmt.executeQuery("SELECT * FROM `tiledb://TileDB-Inc/quickstart_sparse`");
 
@@ -73,7 +73,7 @@ public class JDBCTest {
   public void metadataTest() throws ClassNotFoundException, SQLException {
     Class.forName("io.tiledb.TileDBCloudDriver");
 
-    Connection conn = DriverManager.getConnection("jdbc:tiledb-cloud:TileDB-Inc", properties);
+    Connection conn = DriverManager.getConnection("jdbc:tiledb-cloud:dstara", properties);
     Statement stmt = conn.createStatement();
     ResultSet rs = stmt.executeQuery("SELECT * FROM `tiledb://TileDB-Inc/quickstart_sparse`");
     ResultSetMetaData metadata = rs.getMetaData();

--- a/src/test/java/io/tiledb/JDBCTest.java
+++ b/src/test/java/io/tiledb/JDBCTest.java
@@ -43,7 +43,8 @@ public class JDBCTest {
 
   @Before
   public void setup() {
-    token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiODFkYTFhN2EtYzQyOC00ZDU5LTliYzEtOTVmZmZkZTUzMzI4IiwiU2VlZCI6ODQ4NjYzNTczNTQ2NDMwMiwiZXhwIjoxOTIxMDEwMzk5LCJpYXQiOjE3MTc0MTk4NDgsIm5iZiI6MTcxNzQxOTg0OCwic3ViIjoiZHN0YXJhIn0.tCCc4xdoaYwZlFdrv2e59ZNZskCdwyqPXFNGLGiarJ8";
+    token =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiODFkYTFhN2EtYzQyOC00ZDU5LTliYzEtOTVmZmZkZTUzMzI4IiwiU2VlZCI6ODQ4NjYzNTczNTQ2NDMwMiwiZXhwIjoxOTIxMDEwMzk5LCJpYXQiOjE3MTc0MTk4NDgsIm5iZiI6MTcxNzQxOTg0OCwic3ViIjoiZHN0YXJhIn0.tCCc4xdoaYwZlFdrv2e59ZNZskCdwyqPXFNGLGiarJ8";
     properties = new Properties();
     properties.setProperty("apiKey", token);
   }


### PR DESCRIPTION
@ihnorton @jdblischak . We need to make sure that the API token in the secrets of this repo is by a user who can run sql operations on the given namespace. The given namespace is provided in the url. See below.  

This JDBC driver accepts urls of the following type: ```jdbc:tiledb-cloud:dstara``` The last part of this URL is the namespace it uses to charge for the queries.

I hardcoded a personal token to prove my point. I have invalidated this token. CI passed 

